### PR TITLE
Rename validation job and update workflow syntax

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,20 +1,19 @@
-name: "Validate"
+name: Validate
 
 on:
   push:
   pull_request:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions: {}
 
 jobs:
-  validate:
+  validate-hacs:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v4"
       - name: HACS validation
         uses: "hacs/action@main"
         with:
           category: "integration"
-          ignore: brands
-      - name: Hassfest validation
-        uses: "home-assistant/actions/hassfest@master"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for validation. The main focus is on simplifying and refining the validation process by removing unnecessary steps and adding support for manual workflow dispatch.

Workflow improvements:

* Added `workflow_dispatch` trigger to allow manual runs of the validation workflow.
* Changed the job name from `validate` to `validate-hacs`, and removed the `Hassfest validation` step, focusing the workflow solely on HACS validation.
* Removed the `ignore: brands` option from the HACS validation step, ensuring all validations are performed.

Other changes:

* Set `permissions` to an empty object for more explicit permissions management.
* Simplified the workflow name formatting.