### PR TITLE
feat: Fix running models sensor and add version sensor (v1.2.0)

### DIFF
--- a/custom_components/localai_monitor/const.py
+++ b/custom_components/localai_monitor/const.py
@@ -19,6 +19,7 @@ ENDPOINT_MODELS = "/v1/models"
 ENDPOINT_MODELS_JOBS = "/models/jobs"
 ENDPOINT_SYSTEM = "/system"
 ENDPOINT_RESOURCES = "/api/resources"
+ENDPOINT_VERSION = "/version"
 
 # Sensor types
 SENSOR_BACKENDS = "backends"
@@ -27,6 +28,7 @@ SENSOR_MODELS_JOBS = "models_jobs"
 SENSOR_RUNNING_MODELS = "running_models"
 SENSOR_SYSTEM = "system"
 SENSOR_RESOURCES = "resources"
+SENSOR_VERSION = "version"
 
 # Attributes
 ATTR_LAST_UPDATE = "last_update"

--- a/custom_components/localai_monitor/coordinator.py
+++ b/custom_components/localai_monitor/coordinator.py
@@ -21,11 +21,13 @@ from .const import (
     ENDPOINT_MODELS_JOBS,
     ENDPOINT_SYSTEM,
     ENDPOINT_RESOURCES,
+    ENDPOINT_VERSION,
     SENSOR_BACKENDS,
     SENSOR_MODELS,
     SENSOR_MODELS_JOBS,
     SENSOR_SYSTEM,
     SENSOR_RESOURCES,
+    SENSOR_VERSION,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -142,6 +144,9 @@ class LocalAIDataUpdateCoordinator(DataUpdateCoordinator):
                 
                 # Fetch resources (undocumented)
                 data[SENSOR_RESOURCES] = await self._fetch_endpoint(session, ENDPOINT_RESOURCES)
+                
+                # Fetch version
+                data[SENSOR_VERSION] = await self._fetch_endpoint(session, ENDPOINT_VERSION)
                 
                 # Parse model details from /manage page HTML
                 model_details = await self._fetch_model_details(session)

--- a/custom_components/localai_monitor/manifest.json
+++ b/custom_components/localai_monitor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/loryanstrant/HA-LocalAI-Monitor/issues",
   "requirements": [],
-  "version": "1.1.0"
+  "version": "1.2.0"
 }

--- a/custom_components/localai_monitor/sensor.py
+++ b/custom_components/localai_monitor/sensor.py
@@ -21,6 +21,7 @@ from .const import (
     SENSOR_RESOURCES,
     SENSOR_RUNNING_MODELS,
     SENSOR_SYSTEM,
+    SENSOR_VERSION,
 )
 from .coordinator import LocalAIDataUpdateCoordinator
 
@@ -42,6 +43,7 @@ async def async_setup_entry(
         LocalAIRunningModelsSensor(coordinator, entry),
         LocalAISystemSensor(coordinator, entry),
         LocalAIResourcesSensor(coordinator, entry),
+        LocalAIVersionSensor(coordinator, entry),
     ]
 
     async_add_entities(entities)
@@ -282,26 +284,33 @@ class LocalAIRunningModelsSensor(LocalAISensorBase):
         self._attr_name = "Running Models"
         self._attr_icon = "mdi:brain"
 
+    def _get_loaded_models(self) -> list[dict[str, Any]]:
+        """Extract loaded_models from system endpoint data."""
+        if not self.coordinator.data or SENSOR_SYSTEM not in self.coordinator.data:
+            return []
+        system_data = self.coordinator.data[SENSOR_SYSTEM]
+        if not isinstance(system_data, dict):
+            return []
+        loaded = system_data.get("loaded_models", [])
+        if isinstance(loaded, list):
+            return loaded
+        return []
+
     @property
     def native_value(self) -> int:
         """Return the number of running models."""
-        model_details = (self.coordinator.data or {}).get("model_details", {})
-        return sum(
-            1
-            for details in model_details.values()
-            if isinstance(details, dict) and details.get("status") == "Running"
-        )
+        return len(self._get_loaded_models())
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional state attributes."""
         attrs = super().extra_state_attributes
 
-        model_details = (self.coordinator.data or {}).get("model_details", {})
+        loaded_models = self._get_loaded_models()
         running = [
-            {"name": name, "backend": details.get("backend", "unknown")}
-            for name, details in model_details.items()
-            if isinstance(details, dict) and details.get("status") == "Running"
+            {"id": model.get("id", "unknown")}
+            for model in loaded_models
+            if isinstance(model, dict)
         ]
         attrs["running_models"] = running
 
@@ -474,3 +483,32 @@ class LocalAIResourcesSensor(LocalAISensorBase):
         attrs["watchdog_interval"] = data.get("watchdog_interval")
         
         return attrs
+
+
+class LocalAIVersionSensor(LocalAISensorBase):
+    """Sensor for LocalAI version."""
+
+    def __init__(
+        self,
+        coordinator: LocalAIDataUpdateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator, entry, SENSOR_VERSION)
+        self._attr_name = "Version"
+        self._attr_icon = "mdi:tag"
+
+    @property
+    def native_value(self) -> str:
+        """Return the LocalAI version."""
+        if not self.coordinator.data or SENSOR_VERSION not in self.coordinator.data:
+            return "unknown"
+
+        data = self.coordinator.data[SENSOR_VERSION]
+        if data is None:
+            return "unavailable"
+
+        if isinstance(data, dict):
+            return str(data.get("version", "unknown"))
+
+        return "unknown"


### PR DESCRIPTION
## Summary

This PR fixes the Running Models sensor and adds a new Version sensor for LocalAI Monitor v1.2.0.

### Changes

#### Fix: Running Models Sensor
The Running Models sensor previously relied on HTML parsing of the `/manage` page to determine which models were running. This was fragile and broken when the HTML structure changed.

The sensor now uses the `loaded_models` data from the `/system` endpoint response, which reliably provides the list of currently loaded models:
```yaml
loaded_models: 
  - id: LS-TTS-multi-voice
  - id: qwen3.5-4b-vision
```

#### New: Version Sensor
Added a new sensor (`sensor.localai_monitor_version`) that fetches the LocalAI version from the `/version` endpoint and exposes it as a sensor state.

#### Version Bump
Integration version bumped from `1.1.0` to `1.2.0`.

### Files Changed
- `const.py` - Added `ENDPOINT_VERSION` and `SENSOR_VERSION` constants
- `coordinator.py` - Added `/version` endpoint fetch to the data update cycle
- `sensor.py` - Rewrote `LocalAIRunningModelsSensor` to use `loaded_models` from system data; added `LocalAIVersionSensor`
- `manifest.json` - Version bumped to `1.2.0`

### Testing
Tested against a live LocalAI instance in a Home Assistant DEV container:
- **Running Models**: State correctly shows `2` with attributes listing both loaded model IDs
- **Version**: State correctly shows the LocalAI version string from the `/version` endpoint