### PR TITLE
feat: Replace /manage HTML scraping with REST API (v1.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,7 @@ NOTE: This is not for monitoring a "local AI", this is specifically for the prod
 ## Features
 
 - **Model Monitoring**: Track all installed models with detailed information including:
-  - Backend type (llama-cpp, whisper, stablediffusion, etc.)
   - Runtime status (Running, Idle)
-  - Use cases (Chat, TTS, Image, Audio)
-  - MCP (Model Context Protocol) status
   
 - **Backend Tracking**: Monitor installed backends and their metadata
 
@@ -59,7 +56,7 @@ The integration provides the following sensors:
 
 ### Installed Models
 - **State**: Number of installed models
-- **Attributes**: Detailed list of models with backend, status, use cases, and MCP status
+- **Attributes**: List of models with running/idle status (derived from `/system` loaded models)
 
 <img width="1803" height="954" alt="image" src="https://github.com/user-attachments/assets/d08cf45b-7a66-4025-a85f-1d390740bc15" />
 
@@ -139,20 +136,26 @@ entities:
 
 ## Technical Details
 
-- **Model Information Source**: The integration parses LocalAI's `/manage` page HTML to extract detailed model information (backend, status, use cases) since this data isn't available via the API
+- **Model Information Source**: Model running/idle status is determined via the `/system` API endpoint (`loaded_models` field), which replaced the previously used `/manage` HTML page that was removed in LocalAI v4.x.
 - **API Endpoints Used**:
   - `/v1/models` - Model list
   - `/backends` - Backend information
   - `/models/jobs` - Job status
-  - `/system` - System information
+  - `/system` - System information (including loaded/running models)
   - `/api/resources` - Resource usage
-  - `/manage` - HTML parsing for detailed model data
   - `/backend/shutdown` - Model shutdown endpoint
+  - `/backend/monitor` - Backend monitor (query parameter form, fixed in LocalAI v4.2.0)
 
 ## Requirements
 
 - Home Assistant 2025.10.0 or newer
-- A running LocalAI instance
+- LocalAI v4.2.0 or newer (confirmed working with v4.2.4+)
+
+## Compatibility
+
+This integration (v1.3.0+) requires LocalAI **v4.2.0 or newer**. Earlier versions of LocalAI included a `/manage` page that was used for model detail enrichment; this page was removed in v4.x. The integration now uses only the stable REST API endpoints.
+
+If you are running an older version of LocalAI, use integration version **1.2.0** or earlier.
 
 ## Support
 

--- a/custom_components/localai_monitor/coordinator.py
+++ b/custom_components/localai_monitor/coordinator.py
@@ -1,7 +1,6 @@
 """Data coordinator for the LocalAI Manager integration."""
 from asyncio import timeout
 from datetime import datetime, timedelta, timezone
-from html.parser import HTMLParser
 import logging
 from typing import Any
 
@@ -31,70 +30,6 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class ModelTableParser(HTMLParser):
-    """Parse the /manage page HTML to extract model details."""
-    
-    def __init__(self):
-        """Initialize the parser."""
-        super().__init__()
-        self.in_tbody = False
-        self.in_td = False
-        self.current_col = 0
-        self.current_row = {'name': '', 'status': [], 'backend': '', 'usecases': []}
-        self.models = []
-        
-    def handle_starttag(self, tag, attrs):
-        """Handle opening tags."""
-        try:
-            if tag == 'tbody':
-                self.in_tbody = True
-            elif tag == 'tr' and self.in_tbody:
-                self.current_col = 0
-                self.current_row = {'name': '', 'status': [], 'backend': '', 'usecases': []}
-            elif tag == 'td' and self.in_tbody:
-                self.in_td = True
-        except (AttributeError, KeyError, TypeError) as err:
-            _LOGGER.debug("Error in handle_starttag: %s", err)
-            
-    def handle_endtag(self, tag):
-        """Handle closing tags."""
-        try:
-            if tag == 'tbody':
-                self.in_tbody = False
-            elif tag == 'td':
-                self.in_td = False
-                self.current_col += 1
-            elif tag == 'tr' and self.in_tbody and self.current_row.get('name'):
-                self.models.append(self.current_row.copy())
-        except (AttributeError, KeyError, TypeError) as err:
-            _LOGGER.debug("Error in handle_endtag: %s", err)
-            
-    def handle_data(self, data):
-        """Handle text data within tags."""
-        try:
-            if self.in_td:
-                data = data.strip()
-                if not data:
-                    return
-                    
-                # Column 0: Name
-                if self.current_col == 0 and not self.current_row.get('name'):
-                    self.current_row['name'] = data
-                # Column 1: Status (Running, MCP, etc.)
-                elif self.current_col == 1:
-                    if isinstance(self.current_row.get('status'), list):
-                        self.current_row['status'].append(data)
-                # Column 2: Backend
-                elif self.current_col == 2 and not self.current_row.get('backend'):
-                    self.current_row['backend'] = data
-                # Column 3: Use Cases
-                elif self.current_col == 3:
-                    if isinstance(self.current_row.get('usecases'), list):
-                        self.current_row['usecases'].append(data)
-        except (AttributeError, KeyError, TypeError) as err:
-            _LOGGER.debug("Error in handle_data: %s", err)
 
 
 class LocalAIDataUpdateCoordinator(DataUpdateCoordinator):
@@ -148,11 +83,6 @@ class LocalAIDataUpdateCoordinator(DataUpdateCoordinator):
                 # Fetch version
                 data[SENSOR_VERSION] = await self._fetch_endpoint(session, ENDPOINT_VERSION)
                 
-                # Parse model details from /manage page HTML
-                model_details = await self._fetch_model_details(session)
-                if model_details:
-                    data["model_details"] = model_details
-                
                 self.last_update_success_time = datetime.now(timezone.utc)
                 return data
 
@@ -185,65 +115,4 @@ class LocalAIDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.warning("Error fetching %s: %s", endpoint, err)
             return None
 
-    async def _fetch_model_details(self, session) -> dict[str, dict[str, Any]] | None:
-        """Fetch and parse model details from /manage page HTML."""
-        url = f"{self.url}/manage"
-        headers = {"Accept": "text/html"}
-        
-        if self.api_key:
-            headers["Authorization"] = f"Bearer {self.api_key}"
 
-        try:
-            async with session.get(
-                url,
-                headers=headers,
-            ) as response:
-                if response.status == 200:
-                    html = await response.text()
-                    parser = ModelTableParser()
-                    parser.feed(html)
-                    
-                    # Validate that we got some models
-                    if not parser.models:
-                        _LOGGER.warning("No models found in /manage page - HTML structure may have changed")
-                        return None
-                    
-                    # Convert list to dict keyed by model name
-                    model_dict = {}
-                    for model in parser.models:
-                        try:
-                            if not model.get('name'):
-                                continue
-                            # Validate that model has expected fields
-                            if not isinstance(model.get('status'), list) or not isinstance(model.get('usecases'), list):
-                                _LOGGER.debug("Skipping model %s - invalid data structure", model.get('name'))
-                                continue
-                            model_dict[model['name']] = {
-                                'backend': model.get('backend', 'unknown'),
-                                'status': 'Running' if 'Running' in model.get('status', []) else 'Idle',
-                                'usecases': model.get('usecases', []),
-                                'mcp_enabled': 'MCP' in model.get('status', []),
-                            }
-                        except (KeyError, TypeError, AttributeError) as err:
-                            _LOGGER.debug("Skipping model due to parsing error: %s", err)
-                            continue
-                    
-                    if not model_dict:
-                        _LOGGER.warning("Failed to parse any valid models from /manage page")
-                        return None
-                    
-                    _LOGGER.info(
-                        "Parsed %d models from /manage page (first 3: %s)",
-                        len(model_dict),
-                        list(model_dict.keys())[:3]
-                    )
-                    
-                    return model_dict
-                else:
-                    _LOGGER.warning(
-                        "Failed to fetch /manage page: HTTP %s", response.status
-                    )
-                    return None
-        except Exception as err:
-            _LOGGER.warning("Error parsing model details from HTML: %s", err)
-            return None

--- a/custom_components/localai_monitor/manifest.json
+++ b/custom_components/localai_monitor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/loryanstrant/HA-LocalAI-Monitor/issues",
   "requirements": [],
-  "version": "1.2.0"
+  "version": "1.3.0"
 }

--- a/custom_components/localai_monitor/sensor.py
+++ b/custom_components/localai_monitor/sensor.py
@@ -192,21 +192,22 @@ class LocalAIModelsSensor(LocalAISensorBase):
         if isinstance(data, dict) and "data" in data and isinstance(data["data"], list):
             model_ids = [model.get("id", "unknown") for model in data["data"] if isinstance(model, dict)]
             
-            # Get enriched model details from HTML parsing
-            model_details = self.coordinator.data.get("model_details", {})
+            # Determine running models from /system loaded_models
+            running_model_ids: set[str] = set()
+            system_data = self.coordinator.data.get(SENSOR_SYSTEM)
+            if isinstance(system_data, dict):
+                loaded = system_data.get("loaded_models", [])
+                if isinstance(loaded, list):
+                    for entry in loaded:
+                        if isinstance(entry, dict) and entry.get("id"):
+                            running_model_ids.add(entry["id"])
             
-            # Build enriched model list
+            # Build model list with running status
             for model_id in model_ids:
-                model_info = {"id": model_id}
-                
-                # Add details from HTML if available
-                if model_id in model_details:
-                    details = model_details[model_id]
-                    model_info["backend"] = details.get("backend", "unknown")
-                    model_info["status"] = details.get("status", "unknown")
-                    model_info["usecases"] = details.get("usecases", [])
-                    model_info["mcp_enabled"] = details.get("mcp_enabled", False)
-                
+                model_info = {
+                    "id": model_id,
+                    "status": "Running" if model_id in running_model_ids else "Idle",
+                }
                 model_list.append(model_info)
             
             attrs["models"] = model_list


### PR DESCRIPTION
## Problem

The `/manage` page was removed in LocalAI v4.x, causing the following error to repeat every poll cycle:

```
No models found in /manage page - HTML structure may have changed
```

This was tracked upstream in [LocalAI issue #9207](https://github.com/mudler/LocalAI/issues/9207) and addressed in [LocalAI PR #9411](https://github.com/mudler/LocalAI/pull/9411).

## Solution

Replace the HTML scraping approach with the stable REST API:

| Previously (broken) | Now (v1.3.0) |
|---|---|
| Scraped `/manage` HTML page for model names, status, backend, use cases | Uses `/system` endpoint's `loaded_models` field for running status |
| Used custom `ModelTableParser` (HTMLParser subclass) | Pure JSON REST API calls |

### Changes

- **Removed** `ModelTableParser` HTML parser class (~65 lines of fragile HTML parsing code)
- **Removed** `/manage` page fetch from the coordinator update loop
- **Running Models sensor**: Now reads `loaded_models` from `/system` endpoint instead of the HTML table's status column
- **Models sensor**: Enriches each model with `Running`/`Idle` status using the same `loaded_models` data
- **Version sensor**: Already used `/version` endpoint — no change needed
- **Bump version**: `1.2.0` → `1.3.0` in `manifest.json`
- **README**: Updated to document LocalAI v4.2.0+ requirement and explain the migration from `/manage` page

## Testing

Validated against LocalAI **v4.2.4**:

| Sensor | Value |
|---|---|
| Installed Backends | 26 |
| Installed Models | 23 |
| Running Models | 1 (correctly identified loaded model) |
| Model Jobs | 0 |
| Resources | 61.17% |
| System | online |
| Version | v4.2.4 (42a8db35...) |

All 7 entities loaded successfully in a dev Home Assistant instance with no errors.

## Breaking Change

This integration version (v1.3.0+) requires **LocalAI v4.2.0 or newer**. If running an older LocalAI version, use integration v1.2.0 or earlier.